### PR TITLE
Add _hasVaadinListMixin property

### DIFF
--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -16,6 +16,13 @@ This program is available under Apache License Version 2.0, available at https:/
     static get properties() {
       return {
         /**
+         * Used for mixin detection because `instanceof` does not work with mixins.
+         */
+        _hasVaadinListMixin: {
+          value: true
+        },
+
+        /**
          * The index of the item selected in the items array
          */
         selected: {


### PR DESCRIPTION
Connects to https://github.com/vaadin/vaadin-core/issues/136

Add `_hasVaadinListMixin` to simplify detection of `ListMixin` in other components, such as `vaadin-dropdown-menu`.

Instead of `const menu = overlayElement.$.content.querySelector('vaadin-list-box');` we will be able to check by `element._hasVaadinListMixin` condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-list-mixin/15)
<!-- Reviewable:end -->
