### PR TITLE
Fix key search to allow non-text content before text

### DIFF
--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -96,6 +96,12 @@
         <separator></separator>
         <test-item-element disabled>Bay</test-item-element>
         <test-item-element><span>Baz</span></test-item-element>
+        <separator></separator>
+        <test-item-element disabled>Qux</test-item-element>
+        <test-item-element>
+          <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=">
+          <span>Xyzzy</span>
+        </test-item-element>
       </test-list-element>
     </template>
   </test-fixture>
@@ -154,13 +160,13 @@
       it('should have a list of valid items after the DOM `_observer` has been run', () => {
         // DOM _observer runs asynchronously, we need to flush to access items
         nav._observer.flush();
-        expect(nav._navItems.length).to.be.equal(4);
+        expect(nav._navItems.length).to.be.equal(6);
       });
 
       it('`focus` should flush the `_observer` if it is called too soon', () => {
         // focus flushes the observer in order to be run in 3rd party elements initialisation
         nav.focus();
-        expect(nav._navItems.length).to.be.equal(4);
+        expect(nav._navItems.length).to.be.equal(6);
       });
 
       describe('selection', () => {
@@ -269,13 +275,13 @@
 
         it('should move focus to last element on "end" keydown', () => {
           end(nav);
-          expect(nav._navItems[3].focused).to.be.true;
+          expect(nav._navItems[5].focused).to.be.true;
         });
 
         it('should move focus to the most closed enabled element if last is disabled on "end" keydown', () => {
-          nav._navItems[3].disabled = true;
+          nav._navItems[5].disabled = true;
           end(nav);
-          expect(nav._navItems[1].focused).to.be.true;
+          expect(nav._navItems[3].focused).to.be.true;
         });
 
         it('if focus is in last element should move focus to first element on arrow-down', () => {
@@ -314,6 +320,11 @@
           keyDownChar(nav, 'b');
           keyDownChar(nav, 'b');
           expect(nav._navItems[3].focused).to.be.true;
+        });
+
+        it('key seacrh should accept items having non-text content before text', () => {
+          keyDownChar(nav, 'x');
+          expect(nav._navItems[5].focused).to.be.true;
         });
 
         it('focus should loop when search by first letter', () => {

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -133,7 +133,7 @@ This program is available under Apache License Version 2.0, available at https:/
         increment = 1;
         idx = currentIdx + 1;
         condition = item => !item.disabled &&
-          item.textContent.toLowerCase().indexOf(key.toLowerCase()) === 0;
+          item.textContent.trim().toLowerCase().indexOf(key.toLowerCase()) === 0;
       }
 
       idx = this._getAvailableIndex(idx, increment, condition);


### PR DESCRIPTION
Connected to [vaadin/vaadin-dropdown-menu#32](https://github.com/vaadin/vaadin-dropdown-menu/issues/32)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-list-mixin/21)
<!-- Reviewable:end -->
