### PR TITLE
Prevent selection on click with modifier keys

### DIFF
--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -94,6 +94,10 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _onClick(event) {
+      if (event.metaKey || event.shiftKey || event.ctrlKey) {
+        return;
+      }
+
       const item = this._filterItems(event.composedPath())[0];
       let idx;
       if (item && !item.disabled && ((idx = this.items.indexOf(item)) >= 0)) {


### PR DESCRIPTION
Clicks with modifiers should not trigger the selection by default, as the desired outcome of a click with modifiers is very likely different from the default.

See for example vaadin/vaadin-tabs#81 where an anchor element inside a tab should not select the tab if control/meta-clicked, since the browser will open the link on a new tab/window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-list-mixin/30)
<!-- Reviewable:end -->
