### PR TITLE
Check defaultPrevented before clicking

### DIFF
--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -139,16 +139,6 @@
       MockInteractions.keyDownOn(target, letter.charCodeAt(0), modifier, letter);
     }
 
-    function space(target) {
-      MockInteractions.keyDownOn(target, 32, [], ' ');
-      MockInteractions.keyUpOn(target, 32, [], ' ');
-    }
-
-    function enter(target) {
-      MockInteractions.keyDownOn(target, 13, [], 'Enter');
-      MockInteractions.keyUpOn(target, 13, [], 'Enter');
-    }
-
     describe('vaadin-list-mixin', () => {
       let list;
 
@@ -194,17 +184,6 @@
           list.items[3].firstElementChild.click();
           expect(list.selected).to.be.equal(3);
         });
-
-        it('should be selectable with Enter key', () => {
-          enter(list.items[3]);
-          expect(list.selected).to.be.equal(3);
-        });
-
-        it('should be selectable with Space key', () => {
-          space(list.items[3]);
-          expect(list.selected).to.be.equal(3);
-        });
-
 
       });
 

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -113,11 +113,6 @@ This program is available under Apache License Version 2.0, available at https:/
       // IE names for arrows do not include the Arrow prefix
       const key = event.key.replace(/^Arrow/, '');
 
-      if (/^( |SpaceBar|Enter)$/.test(key)) {
-        this._filterItems(event.composedPath())[0].click();
-        return;
-      }
-
       const currentIdx = this.items.indexOf(this.focused);
       let condition = item => !item.disabled;
       let idx, increment;


### PR DESCRIPTION
Fix https://github.com/vaadin/vaadin-tabs/issues/72
Solving multiple (2+) clicks on tab.

**Previous incorrect behaviour (pressing ones, holding space):**
![incorect-tab-click](https://user-images.githubusercontent.com/29372419/37710687-1434a2dc-2d17-11e8-8b5e-746d61fc308f.gif)

**Fixed correct behaviour with this PR (pressing ones, holding space)**
![right-tab-click](https://user-images.githubusercontent.com/29372419/37710725-298c10de-2d17-11e8-9ff4-fa050bace1c9.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-list-mixin/32)
<!-- Reviewable:end -->
