### PR TITLE
Improved keyboard selection with reusable method.

### DIFF
--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -319,9 +319,19 @@
           expect(list.items[3].focused).to.be.true;
         });
 
-        it('should focus the next item whose first letter matches the key pressed', () => {
+        it('should focus the next item whose first letters match the keys pressed', () => {
           keyDownChar(list, 'b');
-          expect(list.items[1].focused).to.be.true;
+          keyDownChar(list, 'a');
+          keyDownChar(list, 'z');
+          expect(list.items[3].focused).to.be.true;
+        });
+
+        it('key search should cycle through items starting with the same letters', () => {
+          keyDownChar(list, 'b');
+          keyDownChar(list, 'a');
+          keyDownChar(list, 'b');
+          keyDownChar(list, 'a');
+          expect(list.items[3].focused).to.be.true;
         });
 
         it('key search should be case insensitive', () => {

--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -99,6 +99,7 @@
           <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=">
           <span>Xyzzy</span>
         </test-item-element>
+        <test-item-element>Bax</test-item-element>
       </test-list-element>
     </template>
   </test-fixture>
@@ -147,13 +148,13 @@
       it('should have a list of valid items after the DOM `_observer` has been run', () => {
         // DOM _observer runs asynchronously, we need to flush to access items
         list._observer.flush();
-        expect(list.items.length).to.be.equal(6);
+        expect(list.items.length).to.be.equal(7);
       });
 
       it('`focus` should flush the `_observer` if it is called too soon', () => {
         // focus flushes the observer in order to be run in 3rd party elements initialisation
         list.focus();
-        expect(list.items.length).to.be.equal(6);
+        expect(list.items.length).to.be.equal(7);
       });
 
       describe('dom', () => {
@@ -161,17 +162,17 @@
         beforeEach(() => list._observer.flush());
 
         it('should update items list when removing nodes', () => {
-          expect(list.items.length).to.be.equal(6);
+          expect(list.items.length).to.be.equal(7);
 
           list.removeChild(list.items[3]);
           list._observer.flush();
-          expect(list.items.length).to.be.equal(5);
+          expect(list.items.length).to.be.equal(6);
         });
 
         it('should update items list when adding nodes', () => {
           list.appendChild(document.createElement('test-item-element'));
           list._observer.flush();
-          expect(list.items.length).to.be.equal(7);
+          expect(list.items.length).to.be.equal(8);
         });
 
         it('should update items list when moving nodes', () => {
@@ -293,13 +294,13 @@
 
         it('should move focus to last element on "end" keydown', () => {
           end(list);
-          expect(list.items[5].focused).to.be.true;
+          expect(list.items[6].focused).to.be.true;
         });
 
         it('should move focus to the most closed enabled element if last is disabled on "end" keydown', () => {
-          list.items[5].disabled = true;
+          list.items[6].disabled = true;
           end(list);
-          expect(list.items[3].focused).to.be.true;
+          expect(list.items[5].focused).to.be.true;
         });
 
         it('if focus is in last element should move focus to first element on arrow-down', () => {
@@ -319,11 +320,29 @@
           expect(list.items[3].focused).to.be.true;
         });
 
+        it('should not focus anything when no matches are found', () => {
+          keyDownChar(list, 'z');
+          expect(list.items[0].focused).to.be.true;
+          list._focus(1);
+          keyDownChar(list, 'z');
+          expect(list.items[1].focused).to.be.true;
+        });
+
         it('should focus the next item whose first letters match the keys pressed', () => {
           keyDownChar(list, 'b');
           keyDownChar(list, 'a');
-          keyDownChar(list, 'z');
-          expect(list.items[3].focused).to.be.true;
+          keyDownChar(list, 'x');
+          expect(list.items[6].focused).to.be.true;
+        });
+
+        it('should reset search buffer after 500ms without any key presses', done => {
+          keyDownChar(list, 'b');
+          keyDownChar(list, 'a');
+          setTimeout(() => {
+            keyDownChar(list, 'x');
+            expect(list.items[5].focused).to.be.true;
+            done();
+          }, 500);
         });
 
         it('key search should cycle through items starting with the same letters', () => {

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -126,7 +126,15 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    searchKey(currentIdx, key) {
+    _searchKey(currentIdx, key) {
+      this._searchReset = Polymer.Debouncer.debounce(
+        this._searchReset,
+        Polymer.Async.timeOut.after(500),
+        () => {
+          // console.log("uh")
+          this._searchBuf = ''
+        }
+      );
       this._searchBuf += key.toLowerCase();
       const increment = 1;
       const condition = item => !item.disabled &&
@@ -134,10 +142,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
       if (!this.items.some(item => item.textContent.replace(/[^a-zA-Z0-9]/g, '').toLowerCase().indexOf(this._searchBuf) === 0)) {
         this._searchBuf = key.toLowerCase();
-      }
-
-      if (currentIdx === undefined) {
-        return this._getAvailableIndex(0, increment, condition);
       }
 
       const idx = this._searchBuf.length === 1 ? currentIdx + 1 : currentIdx;
@@ -155,10 +159,9 @@ This program is available under Apache License Version 2.0, available at https:/
       const currentIdx = this.items.indexOf(this.focused);
 
       if (/[a-zA-Z0-9]/.test(key) && key.length === 1) {
-        const idx = this.searchKey(currentIdx, key);
+        const idx = this._searchKey(currentIdx, key);
         if (idx >= 0) {
           this._focus(idx);
-          event.preventDefault();
         }
         return;
       }

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -130,10 +130,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._searchReset = Polymer.Debouncer.debounce(
         this._searchReset,
         Polymer.Async.timeOut.after(500),
-        () => {
-          // console.log("uh")
-          this._searchBuf = ''
-        }
+        () => this._searchBuf = ''
       );
       this._searchBuf += key.toLowerCase();
       const increment = 1;

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -62,6 +62,14 @@ This program is available under Apache License Version 2.0, available at https:/
           type: Array,
           readOnly: true,
           notify: true
+        },
+
+        /**
+         * The search buffer for the keyboard selection feature.
+         */
+        _searchBuf: {
+          type: String,
+          value: ''
         }
       };
     }
@@ -118,6 +126,24 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    searchKey(currentIdx, key) {
+      this._searchBuf += key.toLowerCase();
+      const increment = 1;
+      const condition = item => !item.disabled &&
+        item.textContent.trim().toLowerCase().startsWith(this._searchBuf);
+
+      if (!this.items.some(item => item.textContent.trim().toLowerCase().startsWith(this._searchBuf))) {
+        this._searchBuf = key.toLowerCase();
+      }
+
+      if (currentIdx === undefined) {
+        return this._getAvailableIndex(0, increment, condition);
+      }
+
+      const idx = this._searchBuf.length === 1 ? currentIdx + 1 : currentIdx;
+      return this._getAvailableIndex(idx, increment, condition);
+    }
+
     _onKeydown(event) {
       if (event.metaKey || event.ctrlKey) {
         return;
@@ -127,7 +153,17 @@ This program is available under Apache License Version 2.0, available at https:/
       const key = event.key.replace(/^Arrow/, '');
 
       const currentIdx = this.items.indexOf(this.focused);
-      let condition = item => !item.disabled;
+
+      if (/[a-zA-Z0-9]/.test(key) && key.length === 1) {
+        const idx = this.searchKey(currentIdx, key);
+        if (idx >= 0) {
+          this._focus(idx);
+          event.preventDefault();
+        }
+        return;
+      }
+
+      const condition = item => !item.disabled;
       let idx, increment;
 
       if (this._vertical && key === 'Up' || !this._vertical && key === 'Left') {
@@ -142,11 +178,6 @@ This program is available under Apache License Version 2.0, available at https:/
       } else if (key === 'End') {
         increment = -1;
         idx = this.items.length - 1;
-      } else if (key.length == 1) {
-        increment = 1;
-        idx = currentIdx + 1;
-        condition = item => !item.disabled &&
-          item.textContent.trim().toLowerCase().indexOf(key.toLowerCase()) === 0;
       }
 
       idx = this._getAvailableIndex(idx, increment, condition);

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -130,9 +130,9 @@ This program is available under Apache License Version 2.0, available at https:/
       this._searchBuf += key.toLowerCase();
       const increment = 1;
       const condition = item => !item.disabled &&
-        item.textContent.trim().toLowerCase().startsWith(this._searchBuf);
+        item.textContent.replace(/[^a-zA-Z0-9]/g, '').toLowerCase().indexOf(this._searchBuf) === 0;
 
-      if (!this.items.some(item => item.textContent.trim().toLowerCase().startsWith(this._searchBuf))) {
+      if (!this.items.some(item => item.textContent.replace(/[^a-zA-Z0-9]/g, '').toLowerCase().indexOf(this._searchBuf) === 0)) {
         this._searchBuf = key.toLowerCase();
       }
 


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-select#184

Improved keyboard selection feature by allowing to search items with multiple starting letters.

Created method to reuse this feature's logic in other components such as vaadin-select.

Tests passed on Firefox, Chrome, IE11, Edge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-list-mixin/50)
<!-- Reviewable:end -->
