### PR TITLE
Mind hidden items in keyboard navigation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,9 @@
   "devDependencies": {
     "iron-test-helpers": "^2.0.0",
     "web-component-tester": "^6.1.5",
-    "webcomponentsjs": "^1.0.0"
+    "webcomponentsjs": "^1.0.0",
+    "vaadin-context-menu": "^4.3.13",
+    "vaadin-select": "^2.1.6",
+    "vaadin-tabs": "^3.0.5"
   }
 }

--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -116,6 +116,18 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="listHidden">
+      <template>
+        <test-list-element style="width: 400px; height: 400px;">
+          <test-item-element>Foo</test-item-element>
+          <test-item-element hidden>Bar</test-item-element>
+          <test-item-element>Bax</test-item-element>
+          <test-item-element disabled>Bay</test-item-element>
+          <test-item-element>Fox</test-item-element>
+        </test-list-element>
+      </template>
+    </test-fixture>
+
   <script>
     function arrowDown(target) {
       MockInteractions.keyDownOn(target, 40, [], 'ArrowDown');
@@ -596,6 +608,25 @@
 
           list.items[3].click();
           expect(list._scrollerElement.scrollTop).to.be.greaterThan(0);
+        });
+      });
+    });
+    describe('vaadin-list-mixin-hidden', () => {
+      let list;
+
+      beforeEach(done => {
+        list = fixture('listHidden');
+        Polymer.RenderStatus.afterNextRender(list, done);
+      });
+
+      describe('focus', () => {
+
+        beforeEach(() => list._focus(0));
+
+        it('should move focus to next not hidden element on "arrow-down" keydown', () => {
+          arrowDown(list);
+          expect(list.items[1].focused).to.be.false;
+          expect(list.items[2].focused).to.be.true;
         });
       });
     });

--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -54,11 +54,16 @@
       <style>
         :host {
           display: block;
-          flex-shrink: 0; /* fix Safari 9 flex bug: https://github.com/philipwalton/flexbugs#flexbug-1 */
+          flex-shrink: 0;
+          /* fix Safari 9 flex bug: https://github.com/philipwalton/flexbugs#flexbug-1 */
         }
 
         :host([hidden]) {
           display: none !important;
+        }
+
+        :host(.hidden-attribute) {
+          display: none;
         }
       </style>
       <slot></slot>
@@ -116,17 +121,18 @@
     </template>
   </test-fixture>
 
-  <test-fixture id="listHidden">
-      <template>
-        <test-list-element style="width: 400px; height: 400px;">
-          <test-item-element>Foo</test-item-element>
-          <test-item-element hidden>Bar</test-item-element>
-          <test-item-element>Bax</test-item-element>
-          <test-item-element disabled>Bay</test-item-element>
-          <test-item-element>Fox</test-item-element>
-        </test-list-element>
-      </template>
-    </test-fixture>
+  <test-fixture id="list-hidden">
+    <template>
+      <test-list-element style="width: 400px; height: 400px;">
+        <test-item-element>Foo</test-item-element>
+        <test-item-element hidden>Bar</test-item-element>
+        <test-item-element>Bax</test-item-element>
+        <test-item-element style="display: none;">Bay</test-item-element>
+        <test-item-element>Fox</test-item-element>
+        <test-item-element class="hidden-attribute">Pub</test-item-element>
+      </test-list-element>
+    </template>
+  </test-fixture>
 
   <script>
     function arrowDown(target) {
@@ -187,7 +193,6 @@
 
         it('should update items list when removing nodes', () => {
           expect(list.items.length).to.be.equal(7);
-
           list.removeChild(list.items[3]);
           list._observer.flush();
           expect(list.items.length).to.be.equal(6);
@@ -615,7 +620,7 @@
       let list;
 
       beforeEach(done => {
-        list = fixture('listHidden');
+        list = fixture('list-hidden');
         Polymer.RenderStatus.afterNextRender(list, done);
       });
 
@@ -623,10 +628,19 @@
 
         beforeEach(() => list._focus(0));
 
-        it('should move focus to next not hidden element on "arrow-down" keydown', () => {
+        it('should move focus to next not hidden element on "arrow-down" keydown, from element is not hidden and the next is hidden', () => {
+          expect(list.items[0].focused).to.be.true;
+          expect(window.ShadyCSS.getComputedStyleValue(list.items[0], 'display')).to.equal('block');
           arrowDown(list);
-          expect(list.items[1].focused).to.be.false;
+          expect(window.ShadyCSS.getComputedStyleValue(list.items[1], 'display')).to.equal('none');
           expect(list.items[2].focused).to.be.true;
+        });
+        it('should move focus to next not hidden element on "arrow-up" keyup, from element is not hidden and the next is hidden', () => {
+          expect(list.items[0].focused).to.be.true;
+          expect(window.ShadyCSS.getComputedStyleValue(list.items[0], 'display')).to.equal('block');
+          arrowUp(list);
+          expect(window.ShadyCSS.getComputedStyleValue(list.items[list.items.length - 1], 'display')).to.equal('none');
+          expect(list.items[list.items.length - 2].focused).to.be.true;
         });
       });
     });

--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -56,6 +56,10 @@
           display: block;
           flex-shrink: 0; /* fix Safari 9 flex bug: https://github.com/philipwalton/flexbugs#flexbug-1 */
         }
+
+        :host([hidden]) {
+          display: none !important;
+        }
       </style>
       <slot></slot>
     </template>

--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -628,18 +628,18 @@
 
         beforeEach(() => list._focus(0));
 
-        it('should move focus to next not hidden element on "arrow-down" keydown, from element is not hidden and the next is hidden', () => {
+        it('should move focus to next not hidden element on "arrow-down"', () => {
           expect(list.items[0].focused).to.be.true;
-          expect(window.ShadyCSS.getComputedStyleValue(list.items[0], 'display')).to.equal('block');
+          expect(getComputedStyle(list.items[0]).getPropertyValue('display')).to.equal('block');
           arrowDown(list);
-          expect(window.ShadyCSS.getComputedStyleValue(list.items[1], 'display')).to.equal('none');
+          expect(getComputedStyle(list.items[1]).getPropertyValue('display')).to.equal('none');
           expect(list.items[2].focused).to.be.true;
         });
-        it('should move focus to next not hidden element on "arrow-up" keyup, from element is not hidden and the next is hidden', () => {
+        it('should move focus to next not hidden element on "arrow-up"', () => {
           expect(list.items[0].focused).to.be.true;
-          expect(window.ShadyCSS.getComputedStyleValue(list.items[0], 'display')).to.equal('block');
+          expect(getComputedStyle(list.items[0]).getPropertyValue('display')).to.equal('block');
           arrowUp(list);
-          expect(window.ShadyCSS.getComputedStyleValue(list.items[list.items.length - 1], 'display')).to.equal('none');
+          expect(getComputedStyle(list.items[list.items.length - 1]).getPropertyValue('display')).to.equal('none');
           expect(list.items[list.items.length - 2].focused).to.be.true;
         });
       });

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -166,7 +166,7 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      const condition = item => !item.disabled;
+      const condition = item => !(item.disabled || item.hidden);
       let idx, increment;
 
       if (this._vertical && key === 'Up' || !this._vertical && key === 'Left') {

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -166,7 +166,7 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      const condition = item => !(item.disabled || item.hidden);
+      const condition = item => !(item.disabled || window.ShadyCSS.getComputedStyleValue(item, 'display') == 'none');
       let idx, increment;
 
       if (this._vertical && key === 'Up' || !this._vertical && key === 'Left') {
@@ -200,6 +200,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         const item = this.items[idx];
+
         if (condition(item)) {
           return idx;
         }

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -166,7 +166,7 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      const condition = item => !(item.disabled || getComputedStyle(item).getPropertyValue('display') == 'none');
+      const condition = item => !(item.disabled || getComputedStyle(item).getPropertyValue('display') === 'none');
       let idx, increment;
 
       if (this._vertical && key === 'Up' || !this._vertical && key === 'Left') {
@@ -192,7 +192,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _getAvailableIndex(idx, increment, condition) {
       const totalItems = this.items.length;
-      for (let i = 0; typeof idx == 'number' && i < totalItems; i++ , idx += (increment || 1)) {
+      for (let i = 0; typeof idx == 'number' && i < totalItems; i++, idx += (increment || 1)) {
         if (idx < 0) {
           idx = totalItems - 1;
         } else if (idx >= totalItems) {

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -166,7 +166,7 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      const condition = item => !(item.disabled || window.ShadyCSS.getComputedStyleValue(item, 'display') == 'none');
+      const condition = item => !(item.disabled || getComputedStyle(item).getPropertyValue('display') == 'none');
       let idx, increment;
 
       if (this._vertical && key === 'Up' || !this._vertical && key === 'Left') {
@@ -192,7 +192,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _getAvailableIndex(idx, increment, condition) {
       const totalItems = this.items.length;
-      for (let i = 0; typeof idx == 'number' && i < totalItems; i++, idx += (increment || 1)) {
+      for (let i = 0; typeof idx == 'number' && i < totalItems; i++ , idx += (increment || 1)) {
         if (idx < 0) {
           idx = totalItems - 1;
         } else if (idx >= totalItems) {


### PR DESCRIPTION
fix bug: the roving tab-index functionality should take hidden items into account so that they're jumped over by checking the hidden or display: none condition.

fixes #51