### PR TITLE
Fix: hidden items in item label based focus

### DIFF
--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -130,6 +130,8 @@
         <test-item-element style="display: none;">Bay</test-item-element>
         <test-item-element>Fox</test-item-element>
         <test-item-element class="hidden-attribute">Pub</test-item-element>
+        <test-item-element>Bin</test-item-element>
+        <test-item-element style="display: none;">Bop</test-item-element>
       </test-list-element>
     </template>
   </test-fixture>
@@ -168,10 +170,11 @@
     }
 
     describe('vaadin-list-mixin', () => {
-      let list;
+      let list, list2;
 
       beforeEach(done => {
         list = fixture('list');
+        list2 = fixture('list-hidden');
         Polymer.RenderStatus.afterNextRender(list, done);
       });
 
@@ -268,6 +271,11 @@
           [-1, -1, -1, 0].forEach((val, idx) => expect(list.items[idx].tabIndex).to.be.equal(val));
         });
 
+        it('should not set tabIndex=0 to hidden items, but the next one in the loop', () => {
+          list2._focus(3);
+          [-1, -1, -1, -1, 0].forEach((val, idx) => expect(list2.items[idx].tabIndex).to.be.equal(val));
+        });
+
         it('should have a `focus()` method focusing item with `tabIndex=0`', done => {
           list._setFocusable(3);
           list.items[3].focus = () => done();
@@ -349,6 +357,12 @@
           expect(list.items[3].focused).to.be.true;
         });
 
+        it('focus loop should skip hidden items', () => {
+          arrowDown(list);
+          arrowDown(list);
+          expect(list.items[3].focused).to.be.true;
+        });
+
         it('should not focus anything when no matches are found', () => {
           keyDownChar(list, 'z');
           expect(list.items[0].focused).to.be.true;
@@ -396,6 +410,12 @@
           keyDownChar(list, 'b');
           keyDownChar(list, 'b');
           expect(list.items[3].focused).to.be.true;
+        });
+
+        it('key search should skip hidden items', () => {
+          keyDownChar(list2, 'b');
+          keyDownChar(list2, 'b');
+          expect(list2.items[6].focused).to.be.true;
         });
 
         it('key seacrh should accept items having non-text content before text', () => {

--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -170,11 +170,10 @@
     }
 
     describe('vaadin-list-mixin', () => {
-      let list, list2;
+      let list;
 
       beforeEach(done => {
         list = fixture('list');
-        list2 = fixture('list-hidden');
         Polymer.RenderStatus.afterNextRender(list, done);
       });
 
@@ -271,11 +270,6 @@
           [-1, -1, -1, 0].forEach((val, idx) => expect(list.items[idx].tabIndex).to.be.equal(val));
         });
 
-        it('should not set tabIndex=0 to hidden items, but the next one in the loop', () => {
-          list2._focus(3);
-          [-1, -1, -1, -1, 0].forEach((val, idx) => expect(list2.items[idx].tabIndex).to.be.equal(val));
-        });
-
         it('should have a `focus()` method focusing item with `tabIndex=0`', done => {
           list._setFocusable(3);
           list.items[3].focus = () => done();
@@ -357,12 +351,6 @@
           expect(list.items[3].focused).to.be.true;
         });
 
-        it('focus loop should skip hidden items', () => {
-          arrowDown(list);
-          arrowDown(list);
-          expect(list.items[3].focused).to.be.true;
-        });
-
         it('should not focus anything when no matches are found', () => {
           keyDownChar(list, 'z');
           expect(list.items[0].focused).to.be.true;
@@ -410,12 +398,6 @@
           keyDownChar(list, 'b');
           keyDownChar(list, 'b');
           expect(list.items[3].focused).to.be.true;
-        });
-
-        it('key search should skip hidden items', () => {
-          keyDownChar(list2, 'b');
-          keyDownChar(list2, 'b');
-          expect(list2.items[6].focused).to.be.true;
         });
 
         it('key seacrh should accept items having non-text content before text', () => {
@@ -636,7 +618,7 @@
         });
       });
     });
-    describe('vaadin-list-mixin-hidden', () => {
+    describe('hidden-items', () => {
       let list;
 
       beforeEach(done => {
@@ -655,12 +637,30 @@
           expect(getComputedStyle(list.items[1]).getPropertyValue('display')).to.equal('none');
           expect(list.items[2].focused).to.be.true;
         });
+
         it('should move focus to next not hidden element on "arrow-up"', () => {
           expect(list.items[0].focused).to.be.true;
           expect(getComputedStyle(list.items[0]).getPropertyValue('display')).to.equal('block');
           arrowUp(list);
           expect(getComputedStyle(list.items[list.items.length - 1]).getPropertyValue('display')).to.equal('none');
           expect(list.items[list.items.length - 2].focused).to.be.true;
+        });
+
+        it('should not set tabIndex=0 to hidden items, but the next one in the loop', () => {
+          list._focus(1);
+          [-1, -1, 0].forEach((val, idx) => expect(list.items[idx].tabIndex).to.be.equal(val));
+        });
+
+        it('key search should skip hidden items', () => {
+          keyDownChar(list, 'b');
+          keyDownChar(list, 'b');
+          expect(list.items[6].focused).to.be.true;
+        });
+
+        it('focus loop should skip hidden items', () => {
+          arrowDown(list);
+          arrowDown(list);
+          expect(list.items[4].focused).to.be.true;
         });
       });
     });

--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -651,13 +651,13 @@
           [-1, -1, 0].forEach((val, idx) => expect(list.items[idx].tabIndex).to.be.equal(val));
         });
 
-        it('key search should skip hidden items', () => {
+        it('should skip hidden items to key search', () => {
           keyDownChar(list, 'b');
           keyDownChar(list, 'b');
           expect(list.items[6].focused).to.be.true;
         });
 
-        it('focus loop should skip hidden items', () => {
+        it('should skip hidden items to focus loop', () => {
           arrowDown(list);
           arrowDown(list);
           expect(list.items[4].focused).to.be.true;

--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -635,7 +635,7 @@
           expect(getComputedStyle(list.items[0]).getPropertyValue('display')).to.equal('block');
           arrowDown(list);
           expect(getComputedStyle(list.items[1]).getPropertyValue('display')).to.equal('none');
-          expect(list.items[2].focused).to.be.true;
+          expect(list.items.filter(item => item.textContent === 'Bax')[0].focused).to.be.true;
         });
 
         it('should move focus to next not hidden element on "arrow-up"', () => {
@@ -643,24 +643,24 @@
           expect(getComputedStyle(list.items[0]).getPropertyValue('display')).to.equal('block');
           arrowUp(list);
           expect(getComputedStyle(list.items[list.items.length - 1]).getPropertyValue('display')).to.equal('none');
-          expect(list.items[list.items.length - 2].focused).to.be.true;
+          expect(list.items.filter(item => item.textContent === 'Bin')[0].focused).to.be.true;
         });
 
         it('should not set tabIndex=0 to hidden items, but the next one in the loop', () => {
-          list._focus(1);
+          arrowDown(list);
           [-1, -1, 0].forEach((val, idx) => expect(list.items[idx].tabIndex).to.be.equal(val));
         });
 
         it('should skip hidden items to key search', () => {
           keyDownChar(list, 'b');
           keyDownChar(list, 'b');
-          expect(list.items[6].focused).to.be.true;
+          expect(list.items.filter(item => item.textContent === 'Bin')[0].focused).to.be.true;
         });
 
         it('should skip hidden items to focus loop', () => {
           arrowDown(list);
           arrowDown(list);
-          expect(list.items[4].focused).to.be.true;
+          expect(list.items.filter(item => item.textContent === 'Fox')[0].focused).to.be.true;
         });
       });
     });

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -208,11 +208,8 @@ This program is available under Apache License Version 2.0, available at https:/
       return -1;
     }
 
-    _isItemHidden (item) {
-      if (getComputedStyle(item).getPropertyValue('display') === 'none') {
-        return true;
-      }
-      return false;
+    _isItemHidden(item) {
+      return getComputedStyle(item).getPropertyValue('display') === 'none';
     }
 
     _setFocusable(idx) {
@@ -223,7 +220,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _focus(idx) {
       const item = this.items[idx];
-      this.items.forEach(e => e.focused = (e === item && !(this._isItemHidden(e) || e.disabled)));
+      this.items.forEach(e => e.focused = e === item);
       this._setFocusable(idx);
       this._scrollToItem(idx);
       item.focus();

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -213,7 +213,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _setFocusable(idx) {
-      idx = this._getAvailableIndex(idx, 1, item => !(item.disabled || this._isItemHidden(item)));
+      idx = this._getAvailableIndex(idx, 1, item => !item.disabled);
       const item = this.items[idx] || this.items[0];
       this.items.forEach(e => e.tabIndex = e === item ? 0 : -1);
     }

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -124,7 +124,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
       const item = this._filterItems(event.composedPath())[0];
       let idx;
-      if (item && !item.disabled && ((idx = this.items.indexOf(item)) >= 0)) {
+      if (item && !(item.disabled ||
+          getComputedStyle(item).getPropertyValue('display') === 'none') &&
+          ((idx = this.items.indexOf(item)) >= 0)) {
         this.selected = idx;
       }
     }
@@ -137,7 +139,7 @@ This program is available under Apache License Version 2.0, available at https:/
       );
       this._searchBuf += key.toLowerCase();
       const increment = 1;
-      const condition = item => !item.disabled &&
+      const condition = item => !(item.disabled || getComputedStyle(item).getPropertyValue('display') === 'none') &&
         item.textContent.replace(/[^a-zA-Z0-9]/g, '').toLowerCase().indexOf(this._searchBuf) === 0;
 
       if (!this.items.some(item => item.textContent.replace(/[^a-zA-Z0-9]/g, '').toLowerCase().indexOf(this._searchBuf) === 0)) {
@@ -208,18 +210,27 @@ This program is available under Apache License Version 2.0, available at https:/
       return -1;
     }
 
+    _setHidden(item) {
+      if (getComputedStyle(item).getPropertyValue('display') === 'none') {
+        item.hidden = true;
+      }
+    }
+
     _setFocusable(idx) {
-      idx = this._getAvailableIndex(idx, 1, item => !item.disabled);
+      idx = this._getAvailableIndex(idx, 1, item => !(item.disabled || getComputedStyle(item).getPropertyValue('display') === 'none'));
       const item = this.items[idx] || this.items[0];
       this.items.forEach(e => e.tabIndex = e === item ? 0 : -1);
     }
 
     _focus(idx) {
       const item = this.items[idx];
-      this.items.forEach(e => e.focused = e === item);
+      this._setHidden(item);
+      this.items.forEach(e => e.focused = (e === item && !(e.hidden || e.disabled)));
       this._setFocusable(idx);
-      this._scrollToItem(idx);
-      item.focus();
+      if (!(item.hidden || item.disabled)) {
+        this._scrollToItem(idx);
+        item.focus();
+      }
     }
 
     focus() {

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -124,9 +124,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       const item = this._filterItems(event.composedPath())[0];
       let idx;
-      if (item && !(item.disabled ||
-          this._isItemHidden(item)) &&
-          ((idx = this.items.indexOf(item)) >= 0)) {
+      if (item && !item.disabled && ((idx = this.items.indexOf(item)) >= 0)) {
         this.selected = idx;
       }
     }

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -125,7 +125,7 @@ This program is available under Apache License Version 2.0, available at https:/
       const item = this._filterItems(event.composedPath())[0];
       let idx;
       if (item && !(item.disabled ||
-          getComputedStyle(item).getPropertyValue('display') === 'none') &&
+          this._isItemHidden(item)) &&
           ((idx = this.items.indexOf(item)) >= 0)) {
         this.selected = idx;
       }
@@ -139,7 +139,7 @@ This program is available under Apache License Version 2.0, available at https:/
       );
       this._searchBuf += key.toLowerCase();
       const increment = 1;
-      const condition = item => !(item.disabled || getComputedStyle(item).getPropertyValue('display') === 'none') &&
+      const condition = item => !(item.disabled || this._isItemHidden(item)) &&
         item.textContent.replace(/[^a-zA-Z0-9]/g, '').toLowerCase().indexOf(this._searchBuf) === 0;
 
       if (!this.items.some(item => item.textContent.replace(/[^a-zA-Z0-9]/g, '').toLowerCase().indexOf(this._searchBuf) === 0)) {
@@ -168,7 +168,7 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      const condition = item => !(item.disabled || getComputedStyle(item).getPropertyValue('display') === 'none');
+      const condition = item => !(item.disabled || this._isItemHidden(item));
       let idx, increment;
 
       if (this._vertical && key === 'Up' || !this._vertical && key === 'Left') {
@@ -210,27 +210,25 @@ This program is available under Apache License Version 2.0, available at https:/
       return -1;
     }
 
-    _setHidden(item) {
+    _isItemHidden (item) {
       if (getComputedStyle(item).getPropertyValue('display') === 'none') {
-        item.hidden = true;
+        return true;
       }
+      return false;
     }
 
     _setFocusable(idx) {
-      idx = this._getAvailableIndex(idx, 1, item => !(item.disabled || getComputedStyle(item).getPropertyValue('display') === 'none'));
+      idx = this._getAvailableIndex(idx, 1, item => !(item.disabled || this._isItemHidden(item)));
       const item = this.items[idx] || this.items[0];
       this.items.forEach(e => e.tabIndex = e === item ? 0 : -1);
     }
 
     _focus(idx) {
       const item = this.items[idx];
-      this._setHidden(item);
-      this.items.forEach(e => e.focused = (e === item && !(e.hidden || e.disabled)));
+      this.items.forEach(e => e.focused = (e === item && !(this._isItemHidden(e) || e.disabled)));
       this._setFocusable(idx);
-      if (!(item.hidden || item.disabled)) {
-        this._scrollToItem(idx);
-        item.focus();
-      }
+      this._scrollToItem(idx);
+      item.focus();
     }
 
     focus() {

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -209,7 +209,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _isItemHidden(item) {
-      return getComputedStyle(item).getPropertyValue('display') === 'none';
+      return getComputedStyle(item).display === 'none';
     }
 
     _setFocusable(idx) {


### PR DESCRIPTION
Hidden Items can be focused with tabIndex = 0.

I fixed it by checking the hidden condition, if the item is hidden, it should be not focused and tabIndex is -1.
The number of issue: #64