### PR TITLE
fix: focus first non-disabled item if all items have tabindex -1

### DIFF
--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -307,6 +307,14 @@
           list.focus();
           expect(spy.calledOnce).to.be.true;
         });
+
+        it('should change tabindex from -1 to 0 on first non-disabled item when focusing it', () => {
+          list.items.forEach((item) => {
+            item.tabIndex = -1;
+          });
+          list.focus();
+          [-1, -1, 0, -1].forEach((val, idx) => expect(list.items[idx].tabIndex).to.equal(val));
+        });
       });
 
       describe('tabIndex when all the items are disabled', () => {

--- a/test/vaadin-list-mixin.html
+++ b/test/vaadin-list-mixin.html
@@ -298,6 +298,15 @@
           list.focus();
           expect(spy.calledOnce).to.be.true;
         });
+
+        it('should call focus() on the first non-disabled item if all items have tabindex -1', () => {
+          list.items.forEach((item) => {
+            item.tabIndex = -1;
+          });
+          const spy = sinon.spy(list.items[2], 'focus');
+          list.focus();
+          expect(spy.calledOnce).to.be.true;
+        });
       });
 
       describe('tabIndex when all the items are disabled', () => {

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -294,7 +294,7 @@ This program is available under Apache License Version 2.0, available at https:/
       } else if (this.items) {
         const idx = this._getAvailableIndex(0, null, item => !item.disabled);
         if (idx >= 0) {
-          this.items[idx].focus();
+          this._focus(idx);
         }
       }
     }

--- a/vaadin-list-mixin.html
+++ b/vaadin-list-mixin.html
@@ -288,8 +288,15 @@ This program is available under Apache License Version 2.0, available at https:/
     focus() {
       // In initialisation (e.g vaadin-select) observer might not been run yet.
       this._observer && this._observer.flush();
-      const firstItem = this.querySelector('[tabindex="0"]') || (this.items ? this.items[0] : null);
-      firstItem && firstItem.focus();
+      const firstItem = this.querySelector('[tabindex="0"]');
+      if (firstItem) {
+        firstItem.focus();
+      } else if (this.items) {
+        const idx = this._getAvailableIndex(0, null, item => !item.disabled);
+        if (idx >= 0) {
+          this.items[idx].focus();
+        }
+      }
     }
 
     /**


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/7228

This is the same fix as https://github.com/vaadin/web-components/pull/7230

## Type of change

- Bugfix