### PR TITLE
chore: update sauce connect launcher

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,55 +4,52 @@ name: Unit Tests
 on: pull_request
 
 jobs:
-  unit-tests-p2:
-    name: Polymer 2 on the CI agent
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Node 12.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12.x
-
-      - name: Check out the source code
-        uses: actions/checkout@v2
-
-      - name: Install latest npm
-        # magi-cli 1.0 requires npm 7 or higher
-        run: "npm install -g npm@8"
-
-      - name: Install global npm dependencies
-        # bower is needed to run 'bower install'
-        # polymer-cli is needed to run the lint step
-        run: "npm install --quiet --no-progress --global bower polymer-cli"
-
-      - name: Install project npm dependencies
-        run: "npm ci"
-
-      - name: Install project Bower dependencies
-        run: "bower install --quiet"
-
-      - name: Run a linter
-        run: "npm run lint"
-
-      # the full set of environments is tested with Polymer 3 below
-      - name: Run unit tests locally (in the VM instance running this job)
-        run: "xvfb-run -s '-screen 0 1024x768x24' npm test"
+# Running local tests is disabled due to outdated dependencies
+# see https://github.com/vaadin/components-team-tasks/issues/628
+#  unit-tests-p2:
+#    name: Polymer 2 on the CI agent
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Set up Node 16.x
+#        uses: actions/setup-node@v4
+#        with:
+#          node-version: 16.x
+#
+#      - name: Check out the source code
+#        uses: actions/checkout@v2
+#
+#      - name: Install global npm dependencies
+#        # bower is needed to run 'bower install'
+#        # polymer-cli is needed to run the lint step
+#        run: "npm install --quiet --no-progress --global bower polymer-cli"
+#
+#      - name: Install project npm dependencies
+#        run: "npm ci"
+#
+#      - name: Install project Bower dependencies
+#        run: "bower install --quiet"
+#
+#      - name: Run automated magi-cli checks
+#        run: "npm run check"
+#
+#      - name: Run a linter
+#        run: "npm run lint"
+#
+#      # the full set of environments is tested with Polymer 3 below
+#      - name: Run unit tests locally (in the VM instance running this job)
+#        run: "xvfb-run -s '-screen 0 1024x768x24' npm test"
 
   unit-tests-p3:
     name: Polymer 3 on SauceLabs
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node 12.x
-        uses: actions/setup-node@v2
+      - name: Set up Node 16.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: Check out the (Polymer 2) source code
         uses: actions/checkout@v2
-
-      - name: Install latest npm
-        # magi-cli 1.0 requires npm 7 or higher
-        run: "npm install -g npm@8"
 
       - name: Install global npm dependencies
         # bower and polymer-modulizer are needed to run the Polymer 3 conversion step

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
 
 ## Running tests from the command line
 
+> [!WARNING]
+> Running tests locally from the CLI does not work due to outdated dependencies. Run tests via SauceLabs or in the browser instead.
+
 1. Install [web-component-tester](https://www.npmjs.com/package/web-component-tester): `npm install -g web-component-tester`
 
 1. When in the `vaadin-list-mixin` directory, run `wct` or `npm test`

--- a/package-lock-p3.json
+++ b/package-lock-p3.json
@@ -9837,8 +9837,7 @@
     },
     "node_modules/sauce-connect-launcher": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.3.2.tgz",
-      "integrity": "sha512-wf0coUlidJ7rmeClgVVBh6Kw55/yalZCY/Un5RgjSnTXRAeGqagnTsTYpZaqC4dCtrY4myuYpOAZXCdbO7lHfQ==",
+      "resolved": "git+ssh://git@github.com/vaadin/sauce-connect-launcher.git#20fca782221404fef626c985e975268bfaba05cd",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -21198,10 +21197,9 @@
       "dev": true
     },
     "sauce-connect-launcher": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.3.2.tgz",
-      "integrity": "sha512-wf0coUlidJ7rmeClgVVBh6Kw55/yalZCY/Un5RgjSnTXRAeGqagnTsTYpZaqC4dCtrY4myuYpOAZXCdbO7lHfQ==",
+      "version": "git+ssh://git@github.com/vaadin/sauce-connect-launcher.git#20fca782221404fef626c985e975268bfaba05cd",
       "dev": true,
+      "from": "sauce-connect-launcher@vaadin/sauce-connect-launcher#upgrade-sauce-connect-5",
       "optional": true,
       "requires": {
         "adm-zip": "~0.4.3",
@@ -23307,7 +23305,7 @@
         "cleankill": "^2.0.0",
         "lodash": "^4.17.10",
         "request": "^2.85.0",
-        "sauce-connect-launcher": "^1.0.0",
+        "sauce-connect-launcher": "vaadin/sauce-connect-launcher#upgrade-sauce-connect-5",
         "temp": "^0.8.1",
         "uuid": "^3.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12115,8 +12115,7 @@
     },
     "node_modules/sauce-connect-launcher": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.3.2.tgz",
-      "integrity": "sha512-wf0coUlidJ7rmeClgVVBh6Kw55/yalZCY/Un5RgjSnTXRAeGqagnTsTYpZaqC4dCtrY4myuYpOAZXCdbO7lHfQ==",
+      "resolved": "git+ssh://git@github.com/vaadin/sauce-connect-launcher.git#20fca782221404fef626c985e975268bfaba05cd",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -27255,10 +27254,9 @@
       "dev": true
     },
     "sauce-connect-launcher": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.3.2.tgz",
-      "integrity": "sha512-wf0coUlidJ7rmeClgVVBh6Kw55/yalZCY/Un5RgjSnTXRAeGqagnTsTYpZaqC4dCtrY4myuYpOAZXCdbO7lHfQ==",
+      "version": "git+ssh://git@github.com/vaadin/sauce-connect-launcher.git#20fca782221404fef626c985e975268bfaba05cd",
       "dev": true,
+      "from": "sauce-connect-launcher@vaadin/sauce-connect-launcher#upgrade-sauce-connect-5",
       "optional": true,
       "requires": {
         "adm-zip": "~0.4.3",
@@ -30703,7 +30701,7 @@
         "cleankill": "^2.0.0",
         "lodash": "^4.17.10",
         "request": "^2.85.0",
-        "sauce-connect-launcher": "^1.0.0",
+        "sauce-connect-launcher": "vaadin/sauce-connect-launcher#upgrade-sauce-connect-5",
         "temp": "^0.8.1",
         "uuid": "^3.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,10 @@
   },
   "devDependencies": {
     "@vaadin/vaadin-component-dev-dependencies": "^3.2.0"
+  },
+  "overrides": {
+    "wct-sauce": {
+      "sauce-connect-launcher": "vaadin/sauce-connect-launcher#upgrade-sauce-connect-5"
+    }
   }
 }

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -9,6 +9,18 @@ var tunneledLocalhost = 'localhost-for-saucelabs';
 module.exports = {
   testTimeout: 180 * 1000,
   verbose: false,
+  plugins: {
+    local: {
+      browserOptions: {
+        chrome: [
+          'headless',
+          'disable-gpu',
+          'no-sandbox'
+        ]
+      }
+    },
+  },
+
   registerHooks: function(context) {
     const testBrowsers = [
       {
@@ -20,11 +32,9 @@ module.exports = {
       'iOS Simulator/iphone@10.3', // should be 9.x, but SauceLabs does not provide that
       'macOS 11/safari@latest',
       'Windows 10/microsoftedge@latest',
-      'Windows 10/microsoftedge@18',
       'Windows 10/internet explorer@11',
       'Windows 10/chrome@latest',
       'Windows 10/firefox@latest',
-      'Windows 10/firefox@78', // latest ESR as of 2021-06-30
     ];
 
     if (env === 'saucelabs') {
@@ -36,5 +46,14 @@ module.exports = {
 
       context.options.plugins.sauce.browsers = testBrowsers;
     }
+
+    // Map legacy tunnel-identifier option to new tunnel-name option
+    context.hookLate('prepare', (done) => {
+      context.options.activeBrowsers.forEach((browser) => {
+        browser['tunnel-name'] = browser['tunnel-identifier'];
+        delete browser['tunnel-identifier'];
+      });
+      done();
+    });
   }
 };


### PR DESCRIPTION
- Upgrade `sauce-connect-launcher` to use custom fork that downloads and launches Sauce Connect 5
- Disable visual tests
- Disable local tests

Part of https://github.com/vaadin/components-team-tasks/issues/628